### PR TITLE
Set status of remaining evaluations to inactive.

### DIFF
--- a/src/controllers/protocolManagement.controller.js
+++ b/src/controllers/protocolManagement.controller.js
@@ -274,10 +274,22 @@ module.exports.fillProtocol = async (req, res) => {
         {
             conflictFields: ['evaluationId']
         })
+
+        const assessmentId = evaluation.assessmentId;
+        const evaluateeId = evaluation.evaluateeId;
+
+        const allEvaluationsOfEvaluateeInAssessment = await Evaluation.findAll({
+            where: {assessmentId: assessmentId, evaluateeId: evaluateeId}
+        })
+
+        allEvaluationsOfEvaluateeInAssessment.forEach((evaluation) => {
+            evaluation.set({status: 'Inactive'})
+            evaluation.save()
+        })
+
         evaluation.set({status: 'In review'})
         evaluation.save()
 
-        const evaluateeId = evaluation.evaluateeId;
 
         const evaluatee = await Evaluatee.findOne({where: {id: evaluateeId}})
 


### PR DESCRIPTION
[[Bug] If teacher has multiple courses, and protocol for one of the courses is already 'In review', it is still possible to fill remaining protocols.](https://tqas-pwr.atlassian.net/jira/software/c/projects/TQAS/boards/2?modal=detail&selectedIssue=TQAS-241)